### PR TITLE
pom: Use https by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<repositories>
 		<repository>
 			<id>eap</id>
-			<url>http://maven.repository.redhat.com/techpreview/all</url>
+			<url>https://maven.repository.redhat.com/techpreview/all</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -21,7 +21,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>eap</id>
-			<url>http://maven.repository.redhat.com/techpreview/all</url>
+			<url>https://maven.repository.redhat.com/techpreview/all</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>


### PR DESCRIPTION
Maven seems to do this redirect internally, but it's a good idea for
all of the normal reasons to do https from the start.
