### PR TITLE
Update mlbparks-template.json

### DIFF
--- a/mlbparks-template.json
+++ b/mlbparks-template.json
@@ -278,7 +278,7 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate",
+                    "type": "Rolling",
                     "resources": {}
                 },
                 "triggers": [


### PR DESCRIPTION
Any reason that this uses a 'recreate' deployment strategy vs a 'rolling'? With the recreate strategy I see an http 503 error for ~1-2 seconds following a successful build, and when I change the strategy to rolling it's error free (most of the time, or 1 error when checking every 100ms). 
